### PR TITLE
Decode classnames; they're encoded to be URL safe

### DIFF
--- a/src/controllers/DataObjectPreviewController.php
+++ b/src/controllers/DataObjectPreviewController.php
@@ -30,6 +30,7 @@ class DataObjectPreviewController extends Controller {
         }
 
         $class = $request->param('ClassName');
+        $class = str_replace('-', '\\', $class);
         if (!class_exists($class)){
             throw new InvalidArgumentException(sprintf(
                 'DataObjectPreviewController: Class of type %s doesn\'t exist',


### PR DESCRIPTION
As per the documentation at:
https://httpd.apache.org/docs/2.4/mod/core.html#allowencodedslashes
Apache will intant 404 any URI that contains an encoded slash.
This is not allowed to be in a .htaccess file, so a configuration
alteration at core is not really an option. Luckily for us PHP
class names cannot contain a hyphen - so this is the recommended
way of dealing with this type of URI Parameter. This means we need
a single line to deal with this when handling the request though.