### PR TITLE
FIX: Also use namespaced templates; with priority.

### DIFF
--- a/src/controllers/DataObjectPreviewController.php
+++ b/src/controllers/DataObjectPreviewController.php
@@ -50,7 +50,10 @@ class DataObjectPreviewController extends Controller {
         } else if ($this->dataobject->hasMethod('renderPreview')) {
             $r = $this->dataobject->renderPreview();
         } else {
-            $r = $this->dataobject->renderWith(self::stripNamespacing($class));
+            $r = $this->dataobject->renderWith([
+                $class,
+                self::stripNamespacing($class)
+            ]);
         }
 
         return $this->customise(array(


### PR DESCRIPTION
lest we be doomed to fail on the mordern SS4 system. Templates
share their class' namespace, and are encouraged to follow the same 
pattern in folder structure as their namespace. We can use the 
renderWith array notation to fall back to the un-namespaced classname 
should a developer still be retaining the old style structure, so we get the 
best of both worlds :)